### PR TITLE
rest: soporte para tablas con guiones bajos

### DIFF
--- a/Generator/Rest/Factory.php
+++ b/Generator/Rest/Factory.php
@@ -169,13 +169,14 @@ class Generator_Rest_Factory
         $controllers = $this->_restPath . '/controllers';
 
         foreach ($entities as $table) {
-
-            $controllerFile = $controllers . '/' . $table . 'Controller.php';
-            $controllerRawFile = $controllers . 'Raw/' . $table . 'Controller.php';
-            $uri = preg_replace("/([A-Z]){1}/", "-$1", lcfirst($table));
+            $controllerName = Generator_StringUtils::toCamelCase($table, true);
+            $controllerFile = $controllers . '/' . $controllerName. 'Controller.php';
+            $controllerRawFile = $controllers . 'Raw/' . $controllerName. 'Controller.php';
+            $uri = preg_replace("/([A-Z]){1}/", "-$1", lcfirst($controllerName));
 
             $data = array(
-                'tableName' => $table,
+                'tableName' => $controllerName,
+                'dbtable' => $table,
                 'uri' => strtolower($uri)
             );
 

--- a/Generator/Rest/templates/rest.tpl.php
+++ b/Generator/Rest/templates/rest.tpl.php
@@ -3,7 +3,7 @@
 
 $namespace = !empty($this->_namespace) ? $this->_namespace . "\\" : "";
 
-$fields = Generator_Db::describeTable($tableName);
+$fields = Generator_Db::describeTable($dbtable);
 $primaryKey = $fields->getPrimaryKey();
 $fields = $this->_prepareFields($fields);
 


### PR DESCRIPTION
Este PR añade soporte para la API REST con tablas que contienen guion bajo solucionando un problema a la hora de convertir el nombre de la tabla a CamelCase.
