### PR TITLE
rest: soporte para campos tipo enum

### DIFF
--- a/Generator/Rest/templates/rest.tpl.php
+++ b/Generator/Rest/templates/rest.tpl.php
@@ -404,7 +404,7 @@ foreach ($fields as $field) {
             'description' => '',
             'params' => array(
                 '<?=$primaryKey->getName()?>' => array(
-                    'type' => '<?=$primaryKey->getType()?>',
+                    'type' => "<?=$primaryKey->getType()?>",
                     'required' => true,
                     'comment' => '[pk]'
                 )
@@ -422,7 +422,7 @@ foreach ($fields as $field) {
     if ($primaryKey->getName() !== $field->getName()) {
         $fieldName = str_replace('FileSize', '', $field->getName());
         echo "                '" . $fieldName . "' => array(\n";
-        echo "                    'type' => '" . $field->getType() . "',\n";
+        echo "                    'type' => \"" . $field->getType() . "\",\n";
         echo "                    'required' => " . ($field->isNullable() ? 'false' : 'true') . ",\n";
         echo "                    'comment' => '" . $field->getComment() . "',\n";
         echo "                ),\n";
@@ -443,7 +443,7 @@ foreach ($fields as $field) {
 
     $fieldName = str_replace('FileSize', '', $field->getName());
     echo "                '" . $fieldName . "' => array(\n";
-    echo "                    'type' => '" . $field->getType() . "',\n";
+    echo "                    'type' => \"" . $field->getType() . "\",\n";
     echo "                    'required' => " . ($field->isNullable() ? 'false' : 'true') . ",\n";
     echo "                    'comment' => '" . ($primaryKey->getName() === $field->getName() ? '[pk]' : $field->getComment()) . "',\n";
     echo "                ),\n";
@@ -455,7 +455,7 @@ foreach ($fields as $field) {
             'description' => '',
             'params' => array(
                 '<?=$primaryKey->getName()?>' => array(
-                    'type' => '<?=$primaryKey->getType()?>',
+                    'type' => "<?=$primaryKey->getType()?>",
                     'required' => true
                 )
             )


### PR DESCRIPTION
Los campos de base de datos con tipo _enum_ devuelven el texto `enum('valor1', 'valor2', 'valor3')` al invocar el metodo `getType()`

Esto rompe el código generado, que emplea comillas simples para contener este valor.
Este fix no es muy elegante pero funciona.
