### PR TITLE
￼ rest: soporte para campos con mas de un guion bajo

### DIFF
--- a/Generator/Rest/templates/rest.tpl.php
+++ b/Generator/Rest/templates/rest.tpl.php
@@ -86,7 +86,10 @@ if (strpos($fieldName, 'FileSize') == false && strpos($fieldName, 'MimeType') ==
 
     if (strpos($fieldName, '_')) {
         $dataName = explode('_', $fieldName);
-        $name = $dataName[0] . ucfirst($dataName[1]);
+        $name = array_shift($dataName);
+        foreach ($dataName as $dataNamePart) {
+            $name .= ucfirst($dataNamePart);
+        }
     } else {
         $name = $fieldName;
     }
@@ -199,7 +202,10 @@ if (strpos($fieldName, 'FileSize') == false && strpos($fieldName, 'MimeType') ==
 
     if (strpos($fieldName, '_')) {
         $dataName = explode('_', $fieldName);
-        $name = $dataName[0] . ucfirst($dataName[1]);
+        $name = array_shift($dataName);
+        foreach ($dataName as $dataNamePart) {
+            $name .= ucfirst($dataNamePart);
+        }
     } else {
         $name = $fieldName;
     }


### PR DESCRIPTION
Actualmente solo se soporta un guion bajo en los nombres de campos a la hora de convertirlos a camel case.

Por ejemplo el campo alice_bob_charlie daba como resultado aliceBob en lugar de aliceBobCharlie.
