### PR TITLE
Añadido soporte para guardar el changeLog en una tabla

### DIFF
--- a/templates/mapper_raw.tpl.php
+++ b/templates/mapper_raw.tpl.php
@@ -373,6 +373,10 @@ endif;//$fields->hasSoftDelete()
 
 <?php if ($etagsExist) { if ($this->_className !== 'EtagVersions') { ?>        $this->_etagChange();<?php } }?>
 
+        // Save Changelog if requested
+        $model->logDelete();
+        $model->saveChangeLog();
+
         return $result;
 
     }
@@ -772,6 +776,10 @@ endif;
             $this->_etagChange();
         }
 <?php } }?>
+
+        if ($model->hasChange()) {
+            $model->saveChangeLog();
+        }
 
         if ($success === true) {
             return $primaryKey;

--- a/templates/model_raw.tpl.php
+++ b/templates/model_raw.tpl.php
@@ -567,7 +567,7 @@ foreach ($fields as $column):
         }
 ?>
         if ($this->_<?=$column->getNormalizedName()?> != $data) {
-            $this->_logChange('<?=$column->getNormalizedName()?>');
+            $this->_logChange('<?=$column->getNormalizedName()?>', $this->_<?=$column->getNormalizedName()?>, $data);
         }
 
 <?php

--- a/templates/model_raw_abstract.tpl.php
+++ b/templates/model_raw_abstract.tpl.php
@@ -86,6 +86,16 @@ abstract class ModelAbstract implements \IteratorAggregate
     protected $_logChanges = true;
 
     /***
+     * Save Logs into Database switcher
+     */
+    protected $_saveChanges = false;
+
+    /***
+     * Author name of the model changes
+     */
+    protected $_authorChanges = "system";
+
+    /***
      * Changed attributes
      */
     protected $_changeLog = array();
@@ -261,6 +271,12 @@ abstract class ModelAbstract implements \IteratorAggregate
         return $this;
     }
 
+    static public function setChangeAuthor($author)
+    {
+        $this->_authorChanges = $author;
+        return $this;
+    }
+
     public function hasChange($field = '')
     {
         if (empty($field)) {
@@ -272,11 +288,11 @@ abstract class ModelAbstract implements \IteratorAggregate
 
         } else {
 
-            if ( in_array($field, $this->_changeLog) ) {
+            if ( array_key_exists($field, $this->_changeLog) ) {
 
                 return true;
 
-            } elseif (in_array(lcfirst($field), $this->_changeLog)) {
+            } elseif ( array_key_exists(lcfirst($field), $this->_changeLog) ) {
 
                 return true;
             }
@@ -287,7 +303,7 @@ abstract class ModelAbstract implements \IteratorAggregate
 
     public function fetchChangelog()
     {
-        return $this->_changeLog;
+        return array_keys($this->_changeLog);
     }
 
     public function resetChangeLog()
@@ -296,10 +312,69 @@ abstract class ModelAbstract implements \IteratorAggregate
         return $this;
     }
 
-    protected final function _logChange($field)
+    public function logDelete()
     {
         if ($this->_logChanges === true) {
-            $this->_changeLog[] = $field;
+            $this->_changeLog['deleted'] = array();
+        }
+    }
+
+    protected function getActionChangeLog()
+    {
+        if (array_key_exists('deleted', $this->_changeLog)) {
+            return "delete";
+        }
+        if (array_key_exists($this->getPrimaryKeyName(), $this->_changeLog)) {
+            if ($this->_changeLog[$this->getPrimaryKeyName()][0] === null) {
+                return "create";
+            }
+        }
+        return "update";
+    }
+
+    public function saveChangeLog()
+    {
+        // Dont save history for this model
+        if ($this->_saveChanges == false) {
+            return;
+        }
+
+        $action = $this->getActionChangeLog();
+        $table_name = $this->_mapper->getDbTable()->info('name');
+        $objid = $this->getPrimaryKey();
+        $changeAuthor = $this->_authorChanges;
+
+        // Add an entry for each changed field
+        foreach ($this->_changeLog as $field => $data) {
+            // Get ChangeLog data
+            $oldValue = array_shift($data);
+            $newValue = array_shift($data);
+
+            // Convert DateTimes to string
+            if ($oldValue instanceof \DateTime)
+                $oldValue = $oldValue->format("Y-m-d H:i:s");
+            if ($newValue instanceof \DateTime)
+                $newValue = $newValue->format("Y-m-d H:i:s");
+
+            // Add a new Change to the history table
+            $entry = new ChangeHistory();
+            $entry->stopChangeLog();
+            $entry->setUser($changeAuthor);
+            $entry->setAction($action);
+            $entry->setTable($table_name);
+            $entry->setObjid($objid);
+            $entry->setField($field);
+            $entry->setOldValue($oldValue);
+            $entry->setNewValue($newValue);
+            $entry->save();
+        }
+
+    }
+
+    protected final function _logChange($field, $old, $new)
+    {
+        if ($this->_logChanges === true) {
+            $this->_changeLog[$field] = array( $old, $new );
         }
     }
 


### PR DESCRIPTION
Este PR añade la posibilidad de guardar un historico de cambios de las entradas en tabalas modificadas a través de de mappers. Es una implementación muy básica, pero este primer approach nos está sirviendo bastante. Se podrían incluir futuras mejoras como informar correctamente el usuario que realiza la modificación (ahora es _system_ siempre) y la posibilidad de excluir ciertos campos (ahora incluyes o excluyes el modelo entero a través del attributo _$_saveChanges_)

La tabla de historico de cambios tendra una entrada por cada campo
modificado en el modelo. Para Mappers en MySQL podría seguir el
siguiente formato:

```
CREATE TABLE `ChangeHistory` (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `user` varchar(50) NOT NULL,
  `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
  `action` varchar(15) NOT NULL,
  `table` varchar(50) NOT NULL,
  `objid` int(10) unsigned NOT NULL,
  `field` varchar(50) NOT NULL,
  `old_value` varchar(250),
  `new_value` varchar(250),
  PRIMARY KEY (`id`)
  ) COMMENT='[entity]';
```

**Por defecto esta funcionalidad está deshabilitada**, pudiendose habilitar
individualmente en el initializador de los modelos que se deseen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/irontec/klear-generator/7)
<!-- Reviewable:end -->
